### PR TITLE
Add ability to name a handler function as 'config' (#1290)

### DIFF
--- a/actix-web-codegen/CHANGES.md
+++ b/actix-web-codegen/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.2.NEXT] - 2020-xx-xx
+
+* Allow the handler function to be named as `config` #1290
+
 ## [0.2.0] - 2019-12-13
 
 * Generate code for actix-web 2.0

--- a/actix-web-codegen/src/route.rs
+++ b/actix-web-codegen/src/route.rs
@@ -195,15 +195,15 @@ impl Route {
             pub struct #name;
 
             impl actix_web::dev::HttpServiceFactory for #name {
-                fn register(self, config: &mut actix_web::dev::AppService) {
+                fn register(self, __config: &mut actix_web::dev::AppService) {
                     #ast
-                    let resource = actix_web::Resource::new(#path)
+                    let __resource = actix_web::Resource::new(#path)
                         .name(#resource_name)
                         .guard(actix_web::guard::#guard())
                         #(.guard(actix_web::guard::fn_guard(#extra_guards)))*
                         .#resource_type(#name);
 
-                    actix_web::dev::HttpServiceFactory::register(resource, config)
+                    actix_web::dev::HttpServiceFactory::register(__resource, __config)
                 }
             }
         };

--- a/actix-web-codegen/tests/test_macro.rs
+++ b/actix-web-codegen/tests/test_macro.rs
@@ -2,6 +2,12 @@ use actix_web::{http, test, web::Path, App, HttpResponse, Responder};
 use actix_web_codegen::{connect, delete, get, head, options, patch, post, put, trace};
 use futures::{future, Future};
 
+// Make sure that we can name function as 'config'
+#[get("/config")]
+async fn config() -> impl Responder {
+    HttpResponse::Ok()
+}
+
 #[get("/test")]
 async fn test_handler() -> impl Responder {
     HttpResponse::Ok()


### PR DESCRIPTION
* eliminate handler naming restrictions #1277

* Update actix-web-codegen/CHANGES.md

Co-authored-by: Yuki Okushi <huyuumi.dev@gmail.com>