### PR TITLE
Fix missing `std::error::Error` implement for `MultipartError`. (#1382)

### DIFF
--- a/actix-multipart/CHANGES.md
+++ b/actix-multipart/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Remove the unused `time` dependency
 
+* Fix missing `std::error::Error` implement for `MultipartError`.
+
 ## [0.2.0] - 2019-12-20
 
 * Release

--- a/actix-multipart/src/error.rs
+++ b/actix-multipart/src/error.rs
@@ -33,6 +33,8 @@ pub enum MultipartError {
     NotConsumed,
 }
 
+impl std::error::Error for MultipartError {}
+
 /// Return `BadRequest` for `MultipartError`
 impl ResponseError for MultipartError {
     fn status_code(&self) -> StatusCode {


### PR DESCRIPTION
* Fix missing `std::error::Error` implement for `MultipartError`.

* Update actix-multipart CHANGES.md.