### PR TITLE
Fix typos in MIGRATION.md (#1470)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -360,7 +360,7 @@
 
 * `actix_web::server` module has been removed. To start http server use `actix_web::HttpServer` type
 
-* StaticFiles and NamedFile has been move to separate create.
+* StaticFiles and NamedFile have been moved to a separate crate.
 
   instead of `use actix_web::fs::StaticFile`
 
@@ -370,7 +370,7 @@
 
   use `use actix_files::NamedFile`
 
-* Multipart has been move to separate create.
+* Multipart has been moved to a separate crate.
 
   instead of `use actix_web::multipart::Multipart`
 


### PR DESCRIPTION
* Fix typos in MIGRATION.md

Those are `crate` not `create`

* Update MIGRATION.md