### PR TITLE
Fix audit issue logging by default peer address (#1485)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,13 @@
 ### Changed
 
 * Resources and Scopes can now access non-overridden data types set on App (or containing scopes) when setting their own data. [#1486]
+
+* Fix audit issue logging by default peer address [#1485]
+
 * Bump minimum supported Rust version to 1.40
+
+[#1485]: https://github.com/actix/actix-web/pull/1485
+
 
 ## [3.0.0-alpha.2] - 2020-05-08
 
@@ -20,6 +26,7 @@
 [#1433]: https://github.com/actix/actix-web/pull/1433
 [#1452]: https://github.com/actix/actix-web/pull/1452
 [#1486]: https://github.com/actix/actix-web/pull/1486
+
 
 ## [3.0.0-alpha.1] - 2020-03-11
 


### PR DESCRIPTION
* Fix audit issue logging by default peer address

By default log format include remote address that is taken from headers.
This is very easy to replace making log untrusted.

Changing default log format value `%a` to peer address we are getting
this trusted data always. Also, remote address option is maintianed and
relegated to `%{r}a` value.

Related  kanidm/kanidm#191.

* Rename peer/remote to remote_addr/realip_remote_addr

Change names to avoid naming confusions. I choose this accord to Nginx
variables and
[ngx_http_realip_module](https://nginx.org/en/docs/http/ngx_http_realip_module.html).

Add more specific documentation about security concerns of using Real IP
in logger.

* Rename security advertise header in doc

* Add fix audit issue logging by default peer adress to changelog

Co-authored-by: Rob Ede <robjtede@icloud.com>